### PR TITLE
feat(DataProvider): added class to support the data api ttdsignature header

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1929,11 +1929,6 @@
         "which": "^2.0.1"
       }
     },
-    "crypto-js": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.0.0.tgz",
-      "integrity": "sha512-bzHZN8Pn+gS7DQA6n+iUmBfl0hO5DJq++QP3U6uTucDtk/0iGpXd/Gg7CGR0p8tJhofJyaKoWBuJI4eAO00BBg=="
-    },
     "cssom": {
       "version": "0.4.4",
       "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.4.4.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1929,6 +1929,11 @@
         "which": "^2.0.1"
       }
     },
+    "crypto-js": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.0.0.tgz",
+      "integrity": "sha512-bzHZN8Pn+gS7DQA6n+iUmBfl0hO5DJq++QP3U6uTucDtk/0iGpXd/Gg7CGR0p8tJhofJyaKoWBuJI4eAO00BBg=="
+    },
     "cssom": {
       "version": "0.4.4",
       "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.4.4.tgz",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "types": "dist/index.d.ts",
   "scripts": {
     "test": "jest --coverage",
+    "test:watch": "jest --watch  --coverageReporters=\"lcov\" --coverage",
     "prepare": "npm run build",
     "build": "tsc",
     "lint": "eslint .",
@@ -90,6 +91,7 @@
     ]
   },
   "dependencies": {
+    "crypto-js": "^4.0.0",
     "node-fetch": "2.6.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "types": "dist/index.d.ts",
   "scripts": {
     "test": "jest --coverage",
-    "test:watch": "jest --watch  --coverageReporters=\"lcov\" --coverage",
+    "test:watch": "jest --watch --coverageReporters=\"lcov\" --coverage",
     "prepare": "npm run build",
     "build": "tsc",
     "lint": "eslint .",

--- a/package.json
+++ b/package.json
@@ -91,7 +91,6 @@
     ]
   },
   "dependencies": {
-    "crypto-js": "^4.0.0",
     "node-fetch": "2.6.1"
   }
 }

--- a/src/dataProvider.spec.ts
+++ b/src/dataProvider.spec.ts
@@ -1,0 +1,106 @@
+import nock from 'nock';
+import { DataProvider } from '.';
+import { RateLimitError, BadRequestError } from './errors';
+
+
+describe('DataProvider Class', () => {
+    const DEFAULT_URL = 'https://use-data.adsrvr.org';
+    const ROUTE = "/data/thirdparty"
+    const EMPTY_ITEMS_PAYLOAD = { DataProviderId: '123', Items: [] }
+
+    beforeAll(() => {
+        nock.disableNetConnect()
+    });
+
+    afterAll(() => {
+        nock.enableNetConnect();
+    });
+
+    afterEach(() => {
+        nock.cleanAll();
+    })
+
+    it('should create an instance with default options set', () => {
+        const instance = new DataProvider("abc");
+
+        expect(instance.options).toEqual({
+            apiUrl: DEFAULT_URL,
+            maxRetries: 3,
+            maxRetryDelay: 60,
+            retryDelay: 5,
+        });
+    });
+
+    it('should create signature from body and secret', () => {
+        const instance = new DataProvider("xyz");
+        expect(instance.createSignature('{"DataProviderId":"123"}'))
+            .toBe('nXJLsNJ+CXasuFPFiChWX323QFY=')
+    })
+
+    it('[post]', async () => {
+        const postScope = nock(DEFAULT_URL)
+            .matchHeader('Content-Type', 'application/json')
+            .matchHeader('TtdSignature', 'qKJM6iH3Co0Ym1DUm/FcP1JDdPg=')
+            .post(ROUTE, JSON.stringify(EMPTY_ITEMS_PAYLOAD))
+            .reply(200, {a: 'pass-through-result'});
+
+        const instance = new DataProvider("xyz");
+
+        const result = await instance.post(ROUTE, EMPTY_ITEMS_PAYLOAD);
+
+        expect(result.status).toBe(200)
+        expect(await result.json()).toEqual({a: 'pass-through-result'})
+
+        expect(postScope.isDone()).toBe(true);
+    });
+
+    describe('error responses', () => {
+        it('should rate limit with no retries', async () => {
+            const postScope = nock(DEFAULT_URL)
+                .post(ROUTE)
+                .reply(429, JSON.stringify('Try again'), {
+                    'retry-after': '0.1',
+                });
+
+            const instance = new DataProvider("xyz", {
+                maxRetries: 0
+            });
+
+            await expect(instance.post(ROUTE, EMPTY_ITEMS_PAYLOAD)).rejects.toBeInstanceOf(RateLimitError);
+
+            expect(postScope.isDone()).toBe(true);
+        });
+
+        it('should rate limit with 1 retries', async () => {
+            const postScope = nock(DEFAULT_URL)
+                .post(ROUTE)
+                .reply(429, JSON.stringify('Try again'), {
+                    'retry-after': '0.01',
+                })
+                .post(ROUTE)
+                .reply(429, JSON.stringify('Try again'), {
+                    'retry-after': '0.01',
+                });
+
+            const instance = new DataProvider("xyz", {
+                maxRetries: 1
+            });
+
+            await expect(instance.post(ROUTE, EMPTY_ITEMS_PAYLOAD)).rejects.toBeInstanceOf(RateLimitError);
+
+            expect(postScope.isDone()).toBe(true);
+        });
+
+        it('should reply with a bad request', async () => {
+            const postScope = nock(DEFAULT_URL)
+                .post(ROUTE)
+                .reply(400, {});
+
+            const instance = new DataProvider("xyz")
+
+            await expect(instance.post(ROUTE, EMPTY_ITEMS_PAYLOAD)).rejects.toBeInstanceOf(BadRequestError);
+            expect(postScope.isDone()).toBe(true);
+        });
+
+    })
+})

--- a/src/dataProvider.spec.ts
+++ b/src/dataProvider.spec.ts
@@ -1,5 +1,6 @@
 import nock from 'nock';
 import { DataProvider } from '.';
+import { DatacenterHostnames } from './dataProvider';
 import { RateLimitError, BadRequestError } from './errors';
 
 
@@ -100,6 +101,22 @@ describe('DataProvider Class', () => {
 
             await expect(instance.post(ROUTE, EMPTY_ITEMS_PAYLOAD)).rejects.toBeInstanceOf(BadRequestError);
             expect(postScope.isDone()).toBe(true);
+        });
+
+        it('should set apiUrl by DatacenterHostnames', () => {
+            const instance = new DataProvider("abc");
+            instance.setApiUrl(DatacenterHostnames.USWestCoast)
+
+            expect(instance.options.apiUrl).toEqual('https://usw-data.adsrvr.org');
+        });
+
+
+        it('should set apiUrl by string', () => {
+            const uri = "http://www.google.com"
+            const instance = new DataProvider("abc");
+            instance.setApiUrl(uri)
+
+            expect(instance.options.apiUrl).toEqual(uri);
         });
 
     })

--- a/src/dataProvider.ts
+++ b/src/dataProvider.ts
@@ -65,14 +65,9 @@ class DataProvider {
     }
 
     /**
-     * Set the API url based on an enumerated list
-     */
-    setApiUrl(dataCenter: DatacenterHostnames): DataProvider;
-
-    /**
      * Set the API Url to an explicit url
      */
-    setApiUrl(arg: string): DataProvider {
+    setApiUrl(arg: DatacenterHostnames | string): DataProvider {
         const values = Object.values(DatacenterHostnames) as Array<string>;
         if (values.includes(arg)) {
             this.options.apiUrl = `https://${arg}`;

--- a/src/dataProvider.ts
+++ b/src/dataProvider.ts
@@ -6,6 +6,15 @@ import CryptoJS from 'crypto-js';
 import Base64 from 'crypto-js/enc-base64';
 
 
+export enum DatacenterHostnames {
+    USEastCoast = 'use-data.adsrvr.org', // US East Coast
+    UKEU = 'euw-data.adsrvr.org', // UK/EU
+    APAC = 'sin-data.adsrvr.org', // APAC
+    USWestCoast = 'usw-data.adsrvr.org', // US West Coast
+    Tokyo = 'tok-data.adsrvr.org', // Tokyo
+    China = 'https://data-cn2.adsrvr.cn' // China
+}
+
 interface DataProviderOptions {
     /**
      * The url of the Tradedesk Data API
@@ -48,12 +57,32 @@ class DataProvider {
     constructor(secretKey: string, options: DataProviderOptions = {}) {
         this.secretKey = secretKey
         this.options = {
-            apiUrl: 'https://use-data.adsrvr.org',
+            apiUrl: `https://${DatacenterHostnames.USEastCoast}`,
             maxRetries: 3,
             maxRetryDelay: 60,
             retryDelay: 5,
             ...options,
         };
+    }
+
+    /**
+     * Set the API url based on an enumerated list
+     */
+    setApiUrl(dataCenter: DatacenterHostnames): DataProvider;
+
+    /**
+     * Set the API Url to an explicit url
+     */
+    setApiUrl(url: string): DataProvider;
+
+    setApiUrl(arg: any): DataProvider {
+        if (Object.values(DatacenterHostnames).includes(arg)) {
+            this.options.apiUrl = `https://${arg}`;
+        } else {
+            this.options.apiUrl = arg;
+        }
+
+        return this;
     }
 
 

--- a/src/dataProvider.ts
+++ b/src/dataProvider.ts
@@ -1,0 +1,152 @@
+import * as http from 'http';
+import fetch, { RequestInit, Response, HeadersInit, BodyInit } from 'node-fetch';
+import { RateLimitError, BadRequestError, InternalServerError } from './errors';
+import delay from './delay';
+import CryptoJS from 'crypto-js';
+import Base64 from 'crypto-js/enc-base64';
+
+
+interface DataProviderOptions {
+    /**
+     * The url of the Tradedesk Data API
+     */
+    apiUrl?: string;
+
+    /**
+     * HTTP(s) Agent to use when making requests
+     */
+    agent?: http.Agent | ((parsedUrl: URL) => http.Agent);
+
+    /**
+     * Max number of retires to try a request when getting rate limited
+     */
+    maxRetries?: number
+
+    /**
+     * Max delay for an exponential back off policy for when retrying requests. Time is in seconds.
+     */
+    maxRetryDelay?: number
+
+    /**
+     * Base delay for an exponential back off policy for when retrying requests. Time is in seconds.
+     */
+    retryDelay?: number
+}
+
+class DataProvider {
+
+     /**
+     * Options used to make requests
+     */
+    public options: DataProviderOptions;
+
+    /**
+     * Provider Provisioned Secret Key
+     */
+    private secretKey: string;
+
+    constructor(secretKey: string, options: DataProviderOptions = {}) {
+        this.secretKey = secretKey
+        this.options = {
+            apiUrl: 'https://use-data.adsrvr.org',
+            maxRetries: 3,
+            maxRetryDelay: 60,
+            retryDelay: 5,
+            ...options,
+        };
+    }
+
+
+    /**
+     * Creates a HMAC SHA1 Signature
+     */
+    createSignature(body: BodyInit): string {
+        return Base64.stringify(CryptoJS.HmacSHA1(body, this.secretKey));
+    }
+
+    /**
+     * Make URL by combining the apiUrl and the given uri
+     */
+    private makeUrl(uri: string): string {
+        return `${this.options.apiUrl}${uri}`;
+    }
+
+    /**
+     * Make a http request with node-fetch with builtin retries
+     */
+    private async request(
+        uri: string,
+        options: RequestInit,
+        attempts = 0,
+    ): Promise<Response> {
+        const ttdSignature = this.createSignature(options.body);
+
+        // Apply token header
+        const mergedOptions: RequestInit = {
+            agent: this.options.agent,
+            ...options,
+            headers: {
+                ...(options.headers || ({} as HeadersInit)),
+                'TtdSignature': ttdSignature,
+            },
+        };
+
+        return fetch(uri, mergedOptions).then((res) => {
+            if (res.ok) {
+                return res;
+            } else if (res.status === 429) {
+                // Hit a Rate Limit, retry if we can
+                if (attempts < this.options.maxRetries) {
+                    // Attempt to use header to set delay before retry
+                    let delayMilliSeconds =
+                        Number(res.headers.get('retry-after')) * 1000;
+
+                    // If no header, attempt a exponential backoff up to `maxRetryDelay`
+                    if (!delayMilliSeconds) {
+                        delayMilliSeconds = Math.min(
+                            this.options.maxRetryDelay * 1000,
+                            (this.options.retryDelay * 1000 * 2) ^
+                            (attempts + 1)
+                        );
+                    }
+
+                    // Execute delay and retry the request
+                    return delay(delayMilliSeconds).then(() =>
+                        this.request(uri, options, attempts + 1)
+                    );
+                }
+
+                // We've exceeded our retry limit and must throw now
+                throw new RateLimitError(res.statusText, attempts, res);
+            } else if (res.status === 400) {
+                // Bad request response, must throw
+                throw new BadRequestError(res.statusText, res);
+            }
+
+            throw new InternalServerError(res.statusText, res);
+        });
+    }
+
+
+    /**
+     * Create a POST request
+     */
+    post(
+        uri: string,
+        payload: Record<string, unknown>,
+        options: RequestInit = {}
+    ): Promise<Response> {
+        return this.request(this.makeUrl(uri), {
+            ...options,
+            method: 'post',
+            body: JSON.stringify(payload),
+            headers: {
+                ...(options.headers || ({} as HeadersInit)),
+                'Content-Type': 'application/json',
+            },
+        });
+    }
+
+}
+
+export default DataProvider;

--- a/src/dataProvider.ts
+++ b/src/dataProvider.ts
@@ -6,12 +6,12 @@ import crypto from 'crypto';
 
 
 export enum DatacenterHostnames {
-    USEastCoast = 'use-data.adsrvr.org', // US East Coast
-    UKEU = 'euw-data.adsrvr.org', // UK/EU
-    APAC = 'sin-data.adsrvr.org', // APAC
-    USWestCoast = 'usw-data.adsrvr.org', // US West Coast
-    Tokyo = 'tok-data.adsrvr.org', // Tokyo
-    China = 'data-cn2.adsrvr.cn' // China
+    USEastCoast = 'https://use-data.adsrvr.org', // US East Coast
+    UKEU = 'https://euw-data.adsrvr.org', // UK/EU
+    APAC = 'https://sin-data.adsrvr.org', // APAC
+    USWestCoast = 'https://usw-data.adsrvr.org', // US West Coast
+    Tokyo = 'https://tok-data.adsrvr.org', // Tokyo
+    China = 'https://data-cn2.adsrvr.cn' // China
 }
 
 interface DataProviderOptions {
@@ -56,7 +56,7 @@ class DataProvider {
     constructor(secretKey: string, options: DataProviderOptions = {}) {
         this.secretKey = secretKey
         this.options = {
-            apiUrl: `https://${DatacenterHostnames.USEastCoast}`,
+            apiUrl: DatacenterHostnames.USEastCoast,
             maxRetries: 3,
             maxRetryDelay: 60,
             retryDelay: 5,
@@ -67,13 +67,8 @@ class DataProvider {
     /**
      * Set the API Url to an explicit url
      */
-    setApiUrl(arg: DatacenterHostnames | string): DataProvider {
-        const values = Object.values(DatacenterHostnames) as Array<string>;
-        if (values.includes(arg)) {
-            this.options.apiUrl = `https://${arg}`;
-        } else {
-            this.options.apiUrl = arg;
-        }
+    setApiUrl(url: DatacenterHostnames | string): DataProvider {
+        this.options.apiUrl = url;
 
         return this;
     }
@@ -84,7 +79,7 @@ class DataProvider {
      */
     createSignature(body: string): string {
         return crypto.createHmac('sha1', this.secretKey)
-            .update( body )
+            .update(body)
             .digest('base64');
     }
 

--- a/src/dataProvider.ts
+++ b/src/dataProvider.ts
@@ -12,7 +12,7 @@ export enum DatacenterHostnames {
     APAC = 'sin-data.adsrvr.org', // APAC
     USWestCoast = 'usw-data.adsrvr.org', // US West Coast
     Tokyo = 'tok-data.adsrvr.org', // Tokyo
-    China = 'https://data-cn2.adsrvr.cn' // China
+    China = 'data-cn2.adsrvr.cn' // China
 }
 
 interface DataProviderOptions {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,11 @@
 import TradeDesk, { ApiUrlEnvironments } from './tradedesk';
 import { Response } from 'node-fetch';
-import DataProvider from './dataProvider';
+import DataProvider, { DatacenterHostnames } from './dataProvider';
 
 export * from './errors';
 export {
     ApiUrlEnvironments,
+    DatacenterHostnames,
     DataProvider,
     Response,
     TradeDesk,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,12 @@
 import TradeDesk, { ApiUrlEnvironments } from './tradedesk';
 import { Response } from 'node-fetch';
+import DataProvider from './dataProvider';
 
 export * from './errors';
 export {
     ApiUrlEnvironments,
+    DataProvider,
     Response,
-    TradeDesk
+    TradeDesk,
 };
 export default TradeDesk;


### PR DESCRIPTION
The Trade Desk has another set of endpoints that make up there Data API Suite which uses a different authentication mechanism than there public api. Each of those endpoint require a header (TtdSignature) that contains a HMACSHA1 base-64 signature  of the json post body along with a secret key provided by TTD. This PR adds a new class DataProvider that adds this header for any post request.

See more https://api.thetradedesk.com/v3/portal/data/doc/DataAuthentication for more info on the TTD endpoints and authentication.


I'm not a big fan of the class name "DataProvider" but I couldn't come up with anything better.  I came up with DataAPI, DataMappingAPI, or DataEnvironment but rejected them. If you have any better names please let me know.




