### PR TITLE
feat: setting max 24 hour auth token expiration

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "test": "jest --coverage",
     "test:watch": "jest --watch --coverageReporters=\"lcov\" --coverage",
+    "test:results": "open ./coverage/lcov-report/index.html",
     "prepare": "husky install",
     "build": "tsc",
     "lint": "eslint .",

--- a/src/tradedesk.spec.ts
+++ b/src/tradedesk.spec.ts
@@ -1,6 +1,7 @@
 import nock from 'nock';
 import TradeDesk, { ApiUrlEnvironments, InternalServerError } from './';
 import { UnauthorizedError, BadRequestError, RateLimitError, ForbiddenError, GoneError } from './errors';
+import {MAX_24H_TOKEN_EXP_IN_MIN} from './tradedesk'
 
 describe('TradeDesk Class', () => {
     beforeAll(() => {
@@ -31,7 +32,23 @@ describe('TradeDesk Class', () => {
         });
     });
 
-    it('should set a token with no given expiration', () => {
+
+    it('should set a maximum 24 hour token when expiration is larger', () => {
+        const instance = new TradeDesk({
+            tokenExpiration: 6000
+        });
+
+        const returnedInstance = instance.setToken('atoken');
+
+        expect(returnedInstance).toBe(instance);
+        expect(instance.token).toEqual('atoken');
+        expect(instance.tokenTime / 1000).toBeCloseTo(
+            (Date.now() + (MAX_24H_TOKEN_EXP_IN_MIN * 60 * 1000)) / 1000,
+            1
+        );
+    });
+
+    it('should set a 24 hour token when no given expiration', () => {
         const instance = new TradeDesk();
 
         const returnedInstance = instance.setToken('atoken');
@@ -39,7 +56,7 @@ describe('TradeDesk Class', () => {
         expect(returnedInstance).toBe(instance);
         expect(instance.token).toEqual('atoken');
         expect(instance.tokenTime / 1000).toBeCloseTo(
-            (Date.now() + 86.4e6 * 365) / 1000,
+            (Date.now() + (MAX_24H_TOKEN_EXP_IN_MIN * 60 * 1000)) / 1000,
             1
         );
     });
@@ -93,6 +110,48 @@ describe('TradeDesk Class', () => {
         expect(result).toBe(instance);
         expect(instance.token).toEqual('atoken');
     });
+
+    it('should login with max 24 hour token', async () => {
+        const loginScope = nock('https://api.thetradedesk.com/v3')
+            .post('/authentication', {
+                Login: 'auser',
+                Password: 'apassword',
+                TokenExpirationInMinutes: MAX_24H_TOKEN_EXP_IN_MIN
+            })
+            .reply(200, {
+                Token: 'atoken'
+            });
+
+        const instance = new TradeDesk();
+
+        const result = await instance.login('auser', 'apassword', 6000);
+
+        expect(loginScope.isDone()).toBe(true);
+        expect(result).toBe(instance);
+        expect(instance.token).toEqual('atoken');
+    });
+
+    it('should login with specified auth token experation', async () => {
+        const loginScope = nock('https://api.thetradedesk.com/v3')
+            .post('/authentication', {
+                Login: 'auser',
+                Password: 'apassword',
+                TokenExpirationInMinutes: 5
+            })
+            .reply(200, {
+                Token: 'atoken'
+            });
+
+        const instance = new TradeDesk();
+
+        const result = await instance.login('auser', 'apassword', 5);
+
+        expect(loginScope.isDone()).toBe(true);
+        expect(result).toBe(instance);
+        expect(instance.token).toEqual('atoken');
+    });
+
+
 
     it('should fail to login', async () => {
         const loginScope = nock('https://api.thetradedesk.com/v3')

--- a/src/tradedesk.spec.ts
+++ b/src/tradedesk.spec.ts
@@ -48,6 +48,21 @@ describe('TradeDesk Class', () => {
         );
     });
 
+    it('should set a maximum 24 hour token when expiration is zero', () => {
+        const instance = new TradeDesk({
+            tokenExpiration: 0
+        });
+
+        const returnedInstance = instance.setToken('atoken');
+
+        expect(returnedInstance).toBe(instance);
+        expect(instance.token).toEqual('atoken');
+        expect(instance.tokenTime / 1000).toBeCloseTo(
+            (Date.now() + (MAX_24H_TOKEN_EXP_IN_MIN * 60 * 1000)) / 1000,
+            1
+        );
+    });
+
     it('should set a 24 hour token when no given expiration', () => {
         const instance = new TradeDesk();
 
@@ -129,6 +144,29 @@ describe('TradeDesk Class', () => {
         expect(loginScope.isDone()).toBe(true);
         expect(result).toBe(instance);
         expect(instance.token).toEqual('atoken');
+    });
+
+    it('should login with max 24 hour token when timeout is zero', async () => {
+        const loginScope = nock('https://api.thetradedesk.com/v3')
+            .post('/authentication', {
+                Login: 'auser',
+                Password: 'apassword'
+            })
+            .reply(200, {
+                Token: 'atoken'
+            });
+
+        const instance = new TradeDesk();
+
+        const result = await instance.login('auser', 'apassword', 0);
+
+        expect(loginScope.isDone()).toBe(true);
+        expect(result).toBe(instance);
+        expect(instance.token).toEqual('atoken');
+        expect(instance.tokenTime / 1000).toBeCloseTo(
+            (Date.now() + (MAX_24H_TOKEN_EXP_IN_MIN * 60 * 1000)) / 1000,
+            1
+        );
     });
 
     it('should login with specified auth token experation', async () => {

--- a/src/tradedesk.ts
+++ b/src/tradedesk.ts
@@ -10,6 +10,8 @@ export enum ApiUrlEnvironments {
     sandbox = 'sandbox'
 }
 
+export const MAX_24H_TOKEN_EXP_IN_MIN = 1440;  // 24 hours
+
 interface TradeDeskOptions {
     /**
      * The url of the Tradedesk API
@@ -32,7 +34,7 @@ interface TradeDeskOptions {
     password?: string;
 
     /**
-     * The number of minutes until the token expires. If this parameter is not set or set to zero, the token will not expire
+     * The number of minutes until the token expires. If this parameter is not set a 24 hour token (maximum) will be created.
      */
     tokenExpiration?: number;
 
@@ -75,15 +77,18 @@ class TradeDesk {
             maxRetryDelay: 60,
             retryDelay: 5,
             ...options,
+            tokenExpiration: options.tokenExpiration > MAX_24H_TOKEN_EXP_IN_MIN ? MAX_24H_TOKEN_EXP_IN_MIN : options.tokenExpiration
         };
     }
 
     setToken(token: string): TradeDesk {
         this.token = token;
 
-        let expiration = 86.4e6 * 365; // one year
+        const MILISECONDS_IN_MIN = 60 * 1000;
+
+        let expiration = MAX_24H_TOKEN_EXP_IN_MIN * MILISECONDS_IN_MIN; // 24 hours
         if (this.options.tokenExpiration) {
-            expiration = this.options.tokenExpiration * 60 * 1000;
+            expiration = this.options.tokenExpiration * MILISECONDS_IN_MIN;
         }
 
         this.tokenTime = Date.now() + expiration;
@@ -157,7 +162,7 @@ class TradeDesk {
         };
 
         if (tokenExpiration) {
-            this.options.tokenExpiration = tokenExpiration;
+            this.options.tokenExpiration = tokenExpiration > 1440 ? 1440 : tokenExpiration;
         }
 
         if (this.options.tokenExpiration) {

--- a/src/tradedesk.ts
+++ b/src/tradedesk.ts
@@ -84,11 +84,11 @@ class TradeDesk {
     setToken(token: string): TradeDesk {
         this.token = token;
 
-        const MILISECONDS_IN_MIN = 60 * 1000;
+        const MILLISECONDS_IN_MIN = 60 * 1000;
 
-        let expiration = MAX_24H_TOKEN_EXP_IN_MIN * MILISECONDS_IN_MIN; // 24 hours
+        let expiration = MAX_24H_TOKEN_EXP_IN_MIN * MILLISECONDS_IN_MIN; // 24 hours
         if (this.options.tokenExpiration) {
-            expiration = this.options.tokenExpiration * MILISECONDS_IN_MIN;
+            expiration = this.options.tokenExpiration * MILLISECONDS_IN_MIN;
         }
 
         this.tokenTime = Date.now() + expiration;
@@ -162,7 +162,7 @@ class TradeDesk {
         };
 
         if (tokenExpiration) {
-            this.options.tokenExpiration = tokenExpiration > 1440 ? 1440 : tokenExpiration;
+            this.options.tokenExpiration = tokenExpiration > MAX_24H_TOKEN_EXP_IN_MIN ? MAX_24H_TOKEN_EXP_IN_MIN : tokenExpiration;
         }
 
         if (this.options.tokenExpiration) {


### PR DESCRIPTION
On February 15, 2022 TTD's [POST/authentication](https://api.thetradedesk.com/v3/portal/api/ref/post-authentication) will only support short lived tokens with expiration of up to 24 hours (1440 minutes).